### PR TITLE
Allow Ruby 3.0

### DIFF
--- a/nmea_plus.gemspec
+++ b/nmea_plus.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     # spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com' to prevent pushes to rubygems.org, or delete to allow pushes to any server."
   end
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency 'racc', '~>1.4', '>= 1.0'
 


### PR DESCRIPTION
This pull request changes the `required_ruby_version` in the gemspec from "anything up to Ruby 3" to "anything above Ruby 2", allowing the gem to install with Ruby 3.

This was necessary as I have an Apple M1 device, and Ruby 2.x doesn't compile cleanly.

<details>
<summary>The tests pass locally with the following output.</summary>

```
rubynerd@Fixie [12:07:54] [~/Code/nmea_plus] [allow-ruby-three] [100% ⚡️ @ 79W] [3.0.2] 
-> % bundle exec rspec
.......................................................................................................................................
.......................................................................................................................................
...................

Finished in 0.13437 seconds (files took 0.12861 seconds to load)
289 examples, 0 failures

Coverage report generated for RSpec to /Users/rubynerd/Code/nmea_plus/coverage. 5475 / 6147 LOC (89.07%) covered.
Coverage report generated for RSpec to /Users/rubynerd/Code/nmea_plus/coverage/coverage.json. 5475 / 6147 LOC (89.07%) covered.
```
</details>

Thank you for creating this gem, please let me know if there's anything else you need to merge & release!